### PR TITLE
使用鑰匙圈儲存熱點密碼

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "ConnectToWifi",
-    platforms: [.iOS(.v11)],
+    platforms: [.iOS(.v12)],
     products: [
         .library(name: "ConnectToWifi", targets: ["ConnectToWifi"]),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,10 @@ let package = Package(
     name: "ConnectToWifi",
     platforms: [.iOS(.v12)],
     products: [
-        .library(name: "ConnectToWifi", targets: ["ConnectToWifi"]),
+        .library(name: "ConnectToWifi", targets: ["ConnectToWifi"])
     ],
     targets: [
         .target(name: "ConnectToWifi", dependencies: []),
-        .testTarget(name: "ConnectToWifiTests", dependencies: ["ConnectToWifi"]),
+        .testTarget(name: "ConnectToWifiTests", dependencies: ["ConnectToWifi"])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # ConnectToWifi
 
-A description of this package.
+使用 Swift Code 連線至指定 Wifi SSID。

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -12,7 +12,8 @@ public struct ConnectToWifi {
     // MARK: Public Function
     
     public static func bySSID(_ SSID: String, password: String, whenConnected: ((Error?) -> Void)? = nil) {
-        let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
+        // let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
+        let configuration: NEHotspotConfiguration = .init(ssid: SSID)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
             whenConnected?(error)
         }

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -8,11 +8,11 @@
 import NetworkExtension
 
 public struct ConnectToWifi {
-    
+
     public static var manager: WifiManager = .shared
-    
+
     // MARK: Public Function
-    
+
     public static func bySSID(
         _ SSID: String,
         password: String? = nil,

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -37,7 +37,7 @@ public struct ConnectToWifi {
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
             whenConnected?(error)
             guard error == nil else { return }
-            manager.save(password, in: SSID)
+            manager.save(password, on: SSID)
         }
     }
 }

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -9,11 +9,14 @@ import NetworkExtension
 
 public struct ConnectToWifi {
     
+    public static var manager: WifiManager = .shared
+    
     // MARK: Public Function
     
     public static func bySSID(_ SSID: String, password: String, whenConnected: ((Error?) -> Void)? = nil) {
-        // let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
-        let configuration: NEHotspotConfiguration = .init(ssid: SSID)
+        manager.save(password, in: SSID)
+        manager.findWifiPassword(by: SSID)
+        let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
             whenConnected?(error)
         }

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -27,7 +27,7 @@ public struct ConnectToWifi {
         }
         return nil
     }
-    
+
     public static func bySSID(
         _ SSID: String,
         password: String,
@@ -36,9 +36,8 @@ public struct ConnectToWifi {
         let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
             whenConnected?(error)
-            if error == nil {
-                manager.save(password, in: SSID)
-            }
+            guard error == nil else { return }
+            manager.save(password, in: SSID)
         }
     }
 }

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -15,6 +15,21 @@ public struct ConnectToWifi {
     
     public static func bySSID(
         _ SSID: String,
+        password: String? = nil,
+        whenConnected handler: ((Error?) -> Void)? = nil
+    ) -> ConnectToWifiError? {
+        if let password = password {
+            bySSID(SSID, password: password, whenConnected: handler)
+        } else if let password = manager.findWifiPassword(by: SSID) {
+            bySSID(SSID, password: password, whenConnected: handler)
+        } else {
+            return .missPassword
+        }
+        return nil
+    }
+    
+    public static func bySSID(
+        _ SSID: String,
         whenNotFindPassword getPasswordByUser: (() -> String),
         whenConnected: ((Error?) -> Void)? = nil
     ) {

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -16,7 +16,7 @@ public struct ConnectToWifi {
     public static func bySSID(
         _ SSID: String,
         password: String? = nil,
-        whenConnected handler: ((Error?) -> Void)? = nil
+        whenConnected handler: ((String, Error?) -> Void)? = nil
     ) -> ConnectToWifiError? {
         if let password = password {
             bySSID(SSID, password: password, whenConnected: handler)
@@ -39,10 +39,10 @@ public struct ConnectToWifi {
         bySSID(SSID, password: password)
     }
     
-    public static func bySSID(_ SSID: String, password: String, whenConnected: ((Error?) -> Void)? = nil) {
+    public static func bySSID(_ SSID: String, password: String, whenConnected: ((String, Error?) -> Void)? = nil) {
         let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
-            whenConnected?(error)
+            whenConnected?(SSID, error)
         }
     }
 }

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -13,6 +13,17 @@ public struct ConnectToWifi {
     
     // MARK: Public Function
     
+    public static func bySSID(
+        _ SSID: String,
+        whenNotFindPassword getPasswordByUser: (() -> String),
+        whenConnected: ((Error?) -> Void)? = nil
+    ) {
+        var findedPassword: String? = manager.findWifiPassword(by: SSID)
+        if findedPassword == nil { findedPassword = getPasswordByUser() }
+        guard let password = findedPassword else { return }
+        bySSID(SSID, password: password)
+    }
+    
     public static func bySSID(_ SSID: String, password: String, whenConnected: ((Error?) -> Void)? = nil) {
         let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -16,7 +16,7 @@ public struct ConnectToWifi {
     public static func bySSID(
         _ SSID: String,
         password: String? = nil,
-        whenConnected handler: ((String, Error?) -> Void)? = nil
+        whenConnected handler: ((Error?) -> Void)? = nil
     ) -> ConnectToWifiError? {
         if let password = password {
             bySSID(SSID, password: password, whenConnected: handler)
@@ -39,10 +39,10 @@ public struct ConnectToWifi {
         bySSID(SSID, password: password)
     }
     
-    public static func bySSID(_ SSID: String, password: String, whenConnected: ((String, Error?) -> Void)? = nil) {
+    public static func bySSID(_ SSID: String, password: String, whenConnected: ((Error?) -> Void)? = nil) {
         let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
-            whenConnected?(SSID, error)
+            whenConnected?(error)
         }
     }
 }

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -37,7 +37,7 @@ public struct ConnectToWifi {
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
             whenConnected?(error)
             guard error == nil else { return }
-            manager.save(password, on: SSID)
+            manager.update(password, on: SSID)
         }
     }
 }

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -14,8 +14,6 @@ public struct ConnectToWifi {
     // MARK: Public Function
     
     public static func bySSID(_ SSID: String, password: String, whenConnected: ((Error?) -> Void)? = nil) {
-        manager.save(password, in: SSID)
-        manager.findWifiPassword(by: SSID)
         let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
             whenConnected?(error)

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -30,16 +30,9 @@ public struct ConnectToWifi {
     
     public static func bySSID(
         _ SSID: String,
-        whenNotFindPassword getPasswordByUser: (() -> String),
+        password: String,
         whenConnected: ((Error?) -> Void)? = nil
     ) {
-        var findedPassword: String? = manager.findWifiPassword(by: SSID)
-        if findedPassword == nil { findedPassword = getPasswordByUser() }
-        guard let password = findedPassword else { return }
-        bySSID(SSID, password: password)
-    }
-    
-    public static func bySSID(_ SSID: String, password: String, whenConnected: ((Error?) -> Void)? = nil) {
         let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
             whenConnected?(error)

--- a/Sources/ConnectToWifi/ConnectToWifi.swift
+++ b/Sources/ConnectToWifi/ConnectToWifi.swift
@@ -36,6 +36,9 @@ public struct ConnectToWifi {
         let configuration: NEHotspotConfiguration = .init(ssid: SSID, passphrase: password, isWEP: false)
         NEHotspotConfigurationManager.shared.apply(configuration) { error in
             whenConnected?(error)
+            if error == nil {
+                manager.save(password, in: SSID)
+            }
         }
     }
 }

--- a/Sources/ConnectToWifi/Entity/ConnectToWifiError.swift
+++ b/Sources/ConnectToWifi/Entity/ConnectToWifiError.swift
@@ -7,8 +7,8 @@
 import Foundation
 
 public enum ConnectToWifiError: Error {
-    
+
     case missPassword
-    
+
     case keychain(error: OSStatus)
 }

--- a/Sources/ConnectToWifi/Entity/ConnectToWifiError.swift
+++ b/Sources/ConnectToWifi/Entity/ConnectToWifiError.swift
@@ -9,4 +9,6 @@ import Foundation
 public enum ConnectToWifiError: Error {
     
     case missPassword
+    
+    case keychain(error: OSStatus)
 }

--- a/Sources/ConnectToWifi/Entity/ConnectToWifiError.swift
+++ b/Sources/ConnectToWifi/Entity/ConnectToWifiError.swift
@@ -1,0 +1,12 @@
+//
+//  ConnectToWifiError.swift
+//
+//  Created by UnpxreTW on 2021/01/04.
+//  Copyright © 2020 UnpxreTW. All rights reserved.
+//
+import Foundation
+
+public enum ConnectToWifiError: Error {
+    
+    case missPassword
+}

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -36,6 +36,7 @@ public final class WifiManager {
         }
         guard errorCode == errSecSuccess else { return [] }
         if let array = result as? Array<Dictionary<String, Any>> {
+            print(array)
             var values = [String: AnyObject]()
             for item in array {
                 if let key = item[kSecAttrAccount as String] as? String,

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -29,7 +29,7 @@ public final class WifiManager {
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecReturnData as String : false,
-            kSecReturnAttributes as String: true,
+            kSecReturnAttributes as String: false,
             kSecReturnRef as String: true
         ]
         var result: AnyObject?
@@ -44,9 +44,6 @@ public final class WifiManager {
             if let key = item[kSecAttrAccount as String] as? String,
                 let value = item[kSecValueData as String] as? Data {
                 values[key] = String(data: value, encoding:.utf8) as AnyObject?
-            } else if let key = item[kSecAttrLabel as String] as? String,
-                let value = item[kSecValueRef as String] {
-                values[key] = value as AnyObject
             }
         }
         print(values)

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -34,26 +34,11 @@ public final class WifiManager {
         let errorCode = withUnsafeMutablePointer(to: &result) {
             SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
         }
-        guard errorCode == errSecSuccess else { return [] }
-        if let array = result as? Array<Dictionary<String, Any>> {
-            print(array)
-            var values = [String: AnyObject?]()
-            for item in array {
-                if let key = item[kSecAttrAccount as String] as? String {
-                    values.updateValue(nil, forKey: key)
-                }
-                if let key = item[kSecAttrAccount as String] as? String,
-                    let value = item[kSecValueData as String] as? Data {
-                    values[key] = String(data: value, encoding:.utf8) as AnyObject?
-                }
-            }
-            print(values)
-            return values.map { $0.key }
-        } else if let array = result as? [String] {
-            print(array)
-            return array
-        }
-        return []
+        guard
+            errorCode == errSecSuccess,
+            let resultArray = result as? [[String : Any]]
+        else { return [] }
+        return resultArray.compactMap { $0[kSecAttrAccount as String] as? String }
     }
     
     public func save(_ password: String, on SSID: String) {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,7 +28,6 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnData as String : kCFBooleanFalse as Any,
             kSecReturnAttributes as String: true,
             kSecReturnRef as String: true
         ]

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -56,10 +56,7 @@ public final class WifiManager {
         }
         guard status == errSecSuccess else { return nil }
         if let data = dataTypeRef as! Data? {
-            print(data)
-        }
-        if let item = dataTypeRef as! [String: Any]? {
-            print(item)
+            print(String(data: data, encoding: .utf8))
         }
         return nil
     }

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,8 +28,8 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            // kSecReturnData as String : kCFBooleanFalse as Any,
-            // kSecReturnAttributes as String: true,
+            kSecReturnData as String : kCFBooleanTrue as Any,
+            kSecReturnAttributes as String: kCFBooleanTrue as Any,
             kSecReturnRef as String: kCFBooleanTrue as Any
         ]
         var result: AnyObject?

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -27,7 +27,7 @@ public final class WifiManager {
     public func getSSIDList() -> [String] {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecReturnAttributes as String: kCFBooleanTrue!,
+            kSecReturnAttributes as String: true,
             kSecMatchLimit as String: kSecMatchLimitAll
         ]
         var result: AnyObject?
@@ -37,8 +37,11 @@ public final class WifiManager {
         guard errorCode == errSecSuccess else { return [] }
         if let array = result as? Array<Dictionary<String, Any>> {
             print(array)
-            var values = [String: AnyObject]()
+            var values = [String: AnyObject?]()
             for item in array {
+                if let key = item[kSecAttrAccount as String] as? String {
+                    values.updateValue(nil, forKey: key)
+                }
                 if let key = item[kSecAttrAccount as String] as? String,
                     let value = item[kSecValueData as String] as? Data {
                     values[key] = String(data: value, encoding:.utf8) as AnyObject?

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -27,6 +27,7 @@ public final class WifiManager {
     public func getSSIDList() -> [String] {
         let query: [String: Any] = [
             kSecClass as String: kSecClassInternetPassword,
+            kSecAttrAccount as String: "",
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecReturnData as String : true,
             kSecReturnAttributes as String: true,

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -24,9 +24,7 @@ public final class WifiManager {
         NEHotspotConfigurationManager.shared.getConfiguredSSIDs { handler($0) }
     }
     
-    // MARK: Internal Function
-    
-    internal func save(_ password: String, in SSID: String) {
+    public func save(_ password: String, in SSID: String) {
         guard let passwordData = password.data(using: .utf8) as CFData? else { return }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -40,6 +38,8 @@ public final class WifiManager {
         }
     }
     
+    // MARK: Internal Function
+    
     internal func findWifiPassword(by SSID: String) -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -50,11 +50,11 @@ public final class WifiManager {
         let status = withUnsafeMutablePointer(to: &dataTypeRef) {
             SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
         }
-        guard status == errSecSuccess else { return nil }
-        if let data = dataTypeRef as! Data? {
-            print(String(data: data, encoding: .utf8))
-        }
-        return nil
+        guard
+            status == errSecSuccess,
+            let data = dataTypeRef as! Data?,
+            let password = String(data: data, encoding: .utf8)
+        else { return nil }
+        return password
     }
-    
 }

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -36,7 +36,7 @@ public final class WifiManager {
         let errorCode = withUnsafeMutablePointer(to: &result) {
             SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
         }
-        guard errorCode == errSecSuccess else { return [] }
+        guard errorCode == noErr else { return [] }
         var values = [String: AnyObject]()
         let array = result as? Array<Dictionary<String, Any>>
         for item in array! {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,9 +28,9 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassInternetPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnData as String : kCFBooleanTrue,
-            kSecReturnAttributes as String: kCFBooleanTrue,
-            kSecReturnRef as String: kCFBooleanTrue
+            kSecReturnData as String : true,
+            kSecReturnAttributes as String: true,
+            kSecReturnRef as String: true
         ]
         var result: AnyObject?
         let errorCode = withUnsafeMutablePointer(to: &result) {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -24,7 +24,7 @@ public final class WifiManager {
         NEHotspotConfigurationManager.shared.getConfiguredSSIDs { handler($0) }
     }
     
-    public func save(_ password: String, in SSID: String) {
+    public func save(_ password: String, on SSID: String) {
         guard let passwordData = password.data(using: .utf8) as CFData? else { return }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -42,7 +42,7 @@ public final class WifiManager {
         
     }
     
-    public func deleteConfig(_ SSID: String) {
+    public func deleteConfig(by SSID: String) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: SSID

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -29,8 +29,8 @@ public final class WifiManager {
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecReturnData as String : false,
-            kSecReturnAttributes as String: false,
-            kSecReturnRef as String: true
+            kSecReturnAttributes as String: true,
+            // kSecReturnRef as String: true
         ]
         var result: AnyObject?
         let errorCode = withUnsafeMutablePointer(to: &result) {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,9 +28,9 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnData as String : kCFBooleanFalse,
-            kSecReturnAttributes as String: true,
-            // kSecReturnRef as String: true
+            // kSecReturnData as String : kCFBooleanFalse as Any,
+            // kSecReturnAttributes as String: true,
+            kSecReturnRef as String: kCFBooleanTrue as Any
         ]
         var result: AnyObject?
         let errorCode = withUnsafeMutablePointer(to: &result) {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -14,13 +14,9 @@ public final class WifiManager {
     
     public static var shared: WifiManager = .init()
     
-    // MARK: Private Variable
-    
     // MARK: Lifecycle
     
-    private init() {
-        
-    }
+    private init() {}
     
     // MARK: Public Function
     

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -1,0 +1,15 @@
+//
+//  WifiManager.swift
+//  ConnectToWifi
+//
+//  Created by UnpxreTW on 2020/12/28.
+//  Copyright © 2020 UnpxreTW. All rights reserved.
+//
+import NetworkExtension
+
+public final class WifiManager {
+    
+    public static func getConfiguredSSIDs(_ handler: @escaping (([String]) -> Void)) {
+        NEHotspotConfigurationManager.shared.getConfiguredSSIDs { handler($0) }
+    }
+}

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,7 +28,7 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnData as String : false,
+            kSecReturnData as String : kCFBooleanFalse as Any,
             kSecReturnAttributes as String: true,
             kSecReturnRef as String: true
         ]

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -26,7 +26,7 @@ public final class WifiManager {
     
     public func getSSIDList() -> [String] {
         let query: [String: Any] = [
-            kSecClass as String: kSecClassInternetPassword,
+            kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: "",
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecReturnData as String : true,
@@ -67,7 +67,7 @@ public final class WifiManager {
     public func update(_ password: String, on SSID: String) {
         guard let passwordData = password.data(using: .utf8) as CFData? else { return }
         let findOldQuery: [String: Any] = [
-            kSecClass as String: kSecClassInternetPassword,
+            kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: SSID
         ]
         let newQuery: [String: Any] = [

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -36,7 +36,7 @@ public final class WifiManager {
         let errorCode = withUnsafeMutablePointer(to: &result) {
             SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
         }
-        print(errorCode)
+        print(errorCode.description)
         guard errorCode == noErr else { return [] }
         var values = [String: AnyObject]()
         let array = result as? Array<Dictionary<String, Any>>

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,9 +28,9 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnData as String : kCFBooleanTrue as Any,
-            kSecReturnAttributes as String: kCFBooleanTrue as Any,
-            kSecReturnRef as String: kCFBooleanTrue as Any
+            kSecReturnData as String : false,
+            kSecReturnAttributes as String: true,
+            kSecReturnRef as String: true
         ]
         var result: AnyObject?
         let errorCode = withUnsafeMutablePointer(to: &result) {
@@ -39,12 +39,15 @@ public final class WifiManager {
         print(errorCode.description)
         guard errorCode == noErr else { return [] }
         var values = [String: AnyObject]()
-        let array = result as? Array<Dictionary<String, Any>>
-        for item in array! {
-            if let key = item[kSecAttrAccount as String] as? String,
-                let value = item[kSecValueData as String] as? Data {
-                values[key] = String(data: value, encoding:.utf8) as AnyObject?
+        if let array = result as? Array<Dictionary<String, Any>> {
+            for item in array {
+                if let key = item[kSecAttrAccount as String] as? String,
+                    let value = item[kSecValueData as String] as? Data {
+                    values[key] = String(data: value, encoding:.utf8) as AnyObject?
+                }
             }
+        } else if let array = result as? [String] {
+            return array
         }
         print(values)
         return values.map { $0.key }

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,7 +28,7 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnData as String : true,
+            kSecReturnData as String : false,
             kSecReturnAttributes as String: true,
             kSecReturnRef as String: true
         ]

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -27,7 +27,6 @@ public final class WifiManager {
     public func getSSIDList() -> [String] {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: "",
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecReturnData as String : true,
             kSecReturnAttributes as String: true,

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -27,8 +27,8 @@ public final class WifiManager {
     public func getSSIDList() -> [String] {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: kCFBooleanTrue!
+            kSecReturnAttributes as String: kCFBooleanTrue!,
+            kSecMatchLimit as String: kSecMatchLimitAll
         ]
         var result: AnyObject?
         let errorCode = withUnsafeMutablePointer(to: &result) {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -36,21 +36,22 @@ public final class WifiManager {
         let errorCode = withUnsafeMutablePointer(to: &result) {
             SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
         }
-        print(errorCode.description)
-        guard errorCode == noErr else { return [] }
-        var values = [String: AnyObject]()
+        guard errorCode == errSecSuccess else { return [] }
         if let array = result as? Array<Dictionary<String, Any>> {
+            var values = [String: AnyObject]()
             for item in array {
                 if let key = item[kSecAttrAccount as String] as? String,
                     let value = item[kSecValueData as String] as? Data {
                     values[key] = String(data: value, encoding:.utf8) as AnyObject?
                 }
             }
+            print(values)
+            return values.map { $0.key }
         } else if let array = result as? [String] {
+            print(array)
             return array
         }
-        print(values)
-        return values.map { $0.key }
+        return []
     }
     
     public func save(_ password: String, on SSID: String) {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -5,11 +5,63 @@
 //  Created by UnpxreTW on 2020/12/28.
 //  Copyright © 2020 UnpxreTW. All rights reserved.
 //
+import os.log
 import NetworkExtension
 
 public final class WifiManager {
     
-    public static func getConfiguredSSIDs(_ handler: @escaping (([String]) -> Void)) {
+    // MARK: Public Variable
+    
+    public static var shared: WifiManager = .init()
+    
+    // MARK: Private Variable
+    
+    // MARK: Lifecycle
+    
+    private init() {
+        
+    }
+    
+    // MARK: Public Function
+    
+    public func getConfiguredSSIDs(_ handler: @escaping (([String]) -> Void)) {
         NEHotspotConfigurationManager.shared.getConfiguredSSIDs { handler($0) }
     }
+    
+    // MARK: Internal Function
+    
+    internal func save(_ password: String, in SSID: String) {
+        guard let passwordData = password.data(using: .utf8) as CFData? else { return }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: SSID,
+            kSecValueData as String: passwordData
+        ]
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            os_log("Save Password Failed", type: .error)
+            return
+        }
+    }
+    
+    internal func findWifiPassword(by SSID: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnData as String: true,
+            kSecAttrAccount as String: SSID
+        ]
+        var dataTypeRef: AnyObject?
+        let status = withUnsafeMutablePointer(to: &dataTypeRef) {
+            SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
+        }
+        guard status == errSecSuccess else { return nil }
+        if let data = dataTypeRef as! Data? {
+            print(data)
+        }
+        if let item = dataTypeRef as! [String: Any]? {
+            print(item)
+        }
+        return nil
+    }
+    
 }

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,7 +28,7 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true
+            kSecReturnAttributes as String: kCFBooleanTrue!
         ]
         var result: AnyObject?
         let errorCode = withUnsafeMutablePointer(to: &result) {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -36,6 +36,7 @@ public final class WifiManager {
         let errorCode = withUnsafeMutablePointer(to: &result) {
             SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
         }
+        print(errorCode)
         guard errorCode == noErr else { return [] }
         var values = [String: AnyObject]()
         let array = result as? Array<Dictionary<String, Any>>

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -14,6 +14,10 @@ public final class WifiManager {
     
     public static var shared: WifiManager = .init()
     
+    // MARK: Private Variable
+    
+    private static var moduleKey = ("WifiManager.SSIDPassword").data(using: .utf8) as CFData? as Any
+    
     // MARK: Lifecycle
     
     private init() {}
@@ -27,6 +31,7 @@ public final class WifiManager {
     public func getSSIDList() -> [String] {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrGeneric as String: WifiManager.moduleKey,
             kSecReturnAttributes as String: true,
             kSecMatchLimit as String: kSecMatchLimitAll
         ]
@@ -45,6 +50,7 @@ public final class WifiManager {
         guard let passwordData = password.data(using: .utf8) as CFData? else { return }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrGeneric as String: WifiManager.moduleKey,
             kSecAttrAccount as String: SSID,
             kSecValueData as String: passwordData
         ]
@@ -55,10 +61,12 @@ public final class WifiManager {
         guard let passwordData = password.data(using: .utf8) as CFData? else { return }
         let findOldQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrGeneric as String: WifiManager.moduleKey,
             kSecAttrAccount as String: SSID
         ]
         let newQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrGeneric as String: WifiManager.moduleKey,
             kSecAttrAccount as String: SSID,
             kSecValueData as String: passwordData
         ]
@@ -76,6 +84,7 @@ public final class WifiManager {
     public func deleteConfig(by SSID: String) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrGeneric as String: WifiManager.moduleKey,
             kSecAttrAccount as String: SSID
         ]
         let status = SecItemDelete(query as CFDictionary)
@@ -91,6 +100,7 @@ public final class WifiManager {
     internal func findWifiPassword(by SSID: String) -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrGeneric as String: WifiManager.moduleKey,
             kSecReturnData as String: true,
             kSecAttrAccount as String: SSID
         ]

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,7 +28,7 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnData as String : false,
+            kSecReturnData as String : kCFBooleanFalse,
             kSecReturnAttributes as String: true,
             // kSecReturnRef as String: true
         ]

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -38,6 +38,23 @@ public final class WifiManager {
         }
     }
     
+    public func update(_ password: String, on SSID: String) {
+        
+    }
+    
+    public func deleteConfig(_ SSID: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: SSID
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess else {
+            os_log("Delete Password Failed", type: .error)
+            return
+        }
+        NEHotspotConfigurationManager.shared.removeConfiguration(forSSID: SSID)
+    }
+    
     // MARK: Internal Function
     
     internal func findWifiPassword(by SSID: String) -> String? {

--- a/Sources/ConnectToWifi/WifiManager.swift
+++ b/Sources/ConnectToWifi/WifiManager.swift
@@ -28,8 +28,7 @@ public final class WifiManager {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true,
-            kSecReturnRef as String: true
+            kSecReturnAttributes as String: true
         ]
         var result: AnyObject?
         let errorCode = withUnsafeMutablePointer(to: &result) {

--- a/Tests/ConnectToWifiTests/ConnectToWifiTests.swift
+++ b/Tests/ConnectToWifiTests/ConnectToWifiTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import ConnectToWifi
 
 final class ConnectToWifiTests: XCTestCase {
+
     func testExample() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
@@ -9,6 +10,6 @@ final class ConnectToWifiTests: XCTestCase {
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testExample", testExample)
     ]
 }

--- a/Tests/ConnectToWifiTests/XCTestManifests.swift
+++ b/Tests/ConnectToWifiTests/XCTestManifests.swift
@@ -3,7 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(ConnectToWifiTests.allTests),
+        testCase(ConnectToWifiTests.allTests)
     ]
 }
 #endif


### PR DESCRIPTION
使用鑰匙圈儲存熱點 SSID 與密碼。
並且當密碼已儲存時可以只使用 SSID 進行連線，API 會自行讀取密碼。
不使用 `NEHotspotConfigurationManager` 讀取已配置的熱點，以避免使用者在系統設定中使用的熱點不會被記錄。