### PR TITLE
錯誤處理

### DIFF
--- a/Sources/ConnectToWifi/Extension/NEHotspotConfigurationError.swift
+++ b/Sources/ConnectToWifi/Extension/NEHotspotConfigurationError.swift
@@ -1,0 +1,20 @@
+//
+//  NEHotspotConfigurationError.swift
+//
+//  Created by UnpxreTW on 2021/01/08.
+//  Copyright © 2020 UnpxreTW. All rights reserved.
+//
+import NetworkExtension
+
+extension NEHotspotConfigurationError {
+    
+    init?(by error: Error?) {
+        guard let error = error else { return nil }
+        let nsError = error as NSError
+        if nsError.domain == "NEHotspotConfigurationErrorDomain" {
+            self.init(rawValue: nsError.code)
+        } else {
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
將 `NEHotspotConfigurationManager` 結果的 `Error` 轉換為比較好處理的 `NEHotspotConfigurationError`